### PR TITLE
Make FixedField#label optional

### DIFF
--- a/src/main/java/com/joutvhu/fixedwidth/parser/annotation/FixedField.java
+++ b/src/main/java/com/joutvhu/fixedwidth/parser/annotation/FixedField.java
@@ -21,7 +21,7 @@ public @interface FixedField {
      *
      * @return label name of the field
      */
-    String label();
+    String label() default "";
 
     /**
      * Setups the start position of the field


### PR DESCRIPTION
Hi there 👋  I think your library is very useful and was wondering if you accept contributions once in a while. Ergonomics are quite good, but I really would like `FixedField#label` to be optional:

The label of FixedFields should work in the same way as
for FixedObject or FixedParam, whose label is optional.
If the FixedField label is blank, the parser already
assigns the name of the backing field as label, which
is a reasonable default.

Thank you for considering this PR.