### PR TITLE
Feed unpadded strings to validation on write

### DIFF
--- a/src/test/java/com/joutvhu/fixedwidth/parser/OptionTests.java
+++ b/src/test/java/com/joutvhu/fixedwidth/parser/OptionTests.java
@@ -23,19 +23,37 @@ class OptionTests {
     }
 
     @Test
-    void optionsWithPadding() {
-        Stone stone = new Stone("blue");
+    void optionsWithDropPadding() {
+        DropPaddingStone stone = new DropPaddingStone("blue");
 
         assertEquals("blue ", fixedParser.export(stone));
-        assertEquals("blue", fixedParser.parse(Stone.class, "blue ").color);
+        assertEquals("blue", fixedParser.parse(DropPaddingStone.class, "blue ").color);
+    }
+
+    @Test
+    void optionsWithKeepPadding() {
+        KeepPaddingStone stone = new KeepPaddingStone("blue");
+
+        assertEquals("blue ", fixedParser.export(stone));
+        assertEquals("blue ", fixedParser.parse(KeepPaddingStone.class, "blue ").color);
     }
 
     @FixedObject
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class Stone {
+    public static class DropPaddingStone {
         @FixedField(length = 5, keepPadding = KeepPadding.DROP)
+        @FixedOption(options = {"blue ", "white"})
+        private String color;
+    }
+
+    @FixedObject
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KeepPaddingStone {
+        @FixedField(length = 5, keepPadding = KeepPadding.KEEP)
         @FixedOption(options = {"blue ", "white"})
         private String color;
     }


### PR DESCRIPTION
When writing, I think the validation routine should work on unpadded strings. This has two reasons:


### Validation stays the same

When
* The reader part does read → trim → validate
* Then the writer part should do write → validate → pad.

Only this way the input to the validation stays the same, because it consists of the string without padding.

### Avoids having the padding character as part of the format

Below tests would also pass if the padding was part of the format or option string, as in

```java
@FixedOption(options = {"blue ", "white"})
private String color;
```
But this would require changing the options or the date format every time the padding requirements change (padding character, padding length) which is not desired. Adding the padding as part of the format feels like a hack and escapes the control of `FixedField#padding`, for example.

Thank you for taking the time 👍 
