### PR TITLE
Discuss: alignment of fixed fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.6.2'
 

--- a/src/test/java/com/joutvhu/fixedwidth/parser/AlignmentTests.java
+++ b/src/test/java/com/joutvhu/fixedwidth/parser/AlignmentTests.java
@@ -1,0 +1,93 @@
+package com.joutvhu.fixedwidth.parser;
+
+import com.joutvhu.fixedwidth.parser.annotation.FixedField;
+import com.joutvhu.fixedwidth.parser.annotation.FixedObject;
+import com.joutvhu.fixedwidth.parser.domain.Alignment;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AlignmentTests {
+
+    private FixedParser fixedParser;
+
+    @BeforeAll
+    public void beforeTest() {
+        this.fixedParser = FixedParser.parser();
+    }
+
+    @ParameterizedTest
+    @MethodSource("samples")
+    void validateFormattedFieldWithPadding(Sample sample) {
+        String output = fixedParser.export(sample.person);
+
+        assertEquals(sample.expected, output);
+    }
+
+    @SuppressWarnings("unused")
+    static List<Sample> samples() {
+        return Arrays.asList(
+                new Sample(new AutoPerson("Bob"), "Bob       "),
+
+                // FIXME "left" alignment means padding to the right to me
+                new Sample(new LeftPerson("Bob"), "Bob       "),
+
+                // FIXME "right" alignment means padding to the left for me
+                new Sample(new RightPerson("Bob"), "       Bob"),
+
+                new Sample(new CenterPerson("Bob"), "   Bob    "),
+
+                // FIXME fixed length = 10, "Emma".length = 4, this means 3 chars to the left, and 3 chars to the right
+                // But the padding routine constructs a string of length 11, 4 spaces to the left, 3 spaces to the right
+                new Sample(new CenterPerson("Emma"), "   Emma   ")
+        );
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class Sample {
+        private Object person;
+        private String expected;
+    }
+
+    @FixedObject
+    @Data
+    @AllArgsConstructor
+    public static class AutoPerson {
+        @FixedField(length = 10, alignment = Alignment.AUTO)
+        private String name;
+    }
+
+    @FixedObject
+    @Data
+    @AllArgsConstructor
+    public static class LeftPerson {
+        @FixedField(length = 10, alignment = Alignment.LEFT)
+        private String name;
+    }
+
+    @FixedObject
+    @Data
+    @AllArgsConstructor
+    public static class RightPerson {
+        @FixedField(length = 10, alignment = Alignment.RIGHT)
+        private String name;
+    }
+
+    @FixedObject
+    @Data
+    @AllArgsConstructor
+    public static class CenterPerson {
+        @FixedField(length = 10, alignment = Alignment.CENTER)
+        private String name;
+    }
+}


### PR DESCRIPTION
I dug deeper into alignment. **This PR contains a couple of failing test cases.** I wanted to check back with you what the specification is supposed to be. Second, this might be breaking changes.

1. The first concern is alignment. I would expect `Alignment.LEFT` to, well, align the string to the left and pad towards the end of the string. Right now `Alignment.LEFT` aligns the string to right and pads the beginning of the string. I see a couple of different options:
    - Declare it works as expected, which is a bit of a tripwire, because it goes against the most common notion of the meaning of 'alignment' - or -
    - Swap the meaning of `Alignment.LEFT` and `Alignment.RIGHT` to better align with common semantics (for example, as seen in [CSS](https://www.w3schools.com/cssref/tryit.asp?filename=trycss_text-align)) - or -
    - Keep the implementation as-is, but rename `Alignment` (both enum and parameter to `FixedField`) to `Padding`. Trivially, I would indeed expect`@FixedField(padding = Padding.RIGHT)` to add padding characters to the end of the string and vice versa.
   
    The last two options sound preferable to me. I would go with swapping the meaning, but it depends how many users this library has. It's a breaking change which causes harm if not noticed. If that change is made, it should probably kick-off a 2.x and a bold changelog entry.

2. Unambiguously, the implementation of `Alignment.CENTER` is incorrect. If the string can be evenly padded to left and right, the result is not centered. In this case the padding algorithm adds one character too many to the front.

Please tell me how you would go about it. I could then proceed to develop fixes for left/right alignment issues as well as the faulty center alignment. Thanks 🙂