### PR TITLE
Trimming is done before the value is retrieved

### DIFF
--- a/src/main/java/com/joutvhu/fixedwidth/parser/support/FixedParseStrategy.java
+++ b/src/main/java/com/joutvhu/fixedwidth/parser/support/FixedParseStrategy.java
@@ -48,8 +48,8 @@ public class FixedParseStrategy implements ReadStrategy, WriteStrategy {
     @Override
     public Object read(FixedTypeInfo info, StringAssembler assembler) {
         info.detectTypeWith(assembler);
-        String value = assembler.getValue();
         assembler.trim(info);
+        String value = assembler.getValue();
         if (assembler.isBlank(info)) {
             if (info.require)
                 throw new NullPointerException(info.buildMessage("{title} cannot be blank."));


### PR DESCRIPTION
Currently, validate is executed with paddings present in the value. In case of decimals it will cause an exception even when keepPadding is set to Drop. 